### PR TITLE
Maintenance update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@natlibfi/passport-natlibfi-keycloak",
-  "version": "3.0.3-alpha.1",
+  "version": "3.0.4-alpha.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/passport-natlibfi-keycloak",
-      "version": "3.0.3-alpha.1",
+      "version": "3.0.4-alpha.1",
       "license": "MIT",
       "dependencies": {
         "@natlibfi/passport-keycloak": "^3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@natlibfi/passport-natlibfi-keycloak",
-  "version": "3.0.4-alpha.1",
+  "version": "3.0.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@natlibfi/passport-natlibfi-keycloak",
-      "version": "3.0.4-alpha.1",
+      "version": "3.0.4",
       "license": "MIT",
       "dependencies": {
         "@natlibfi/passport-keycloak": "^3.0.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1369,12 +1369,12 @@
       }
     },
     "node_modules/jws": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.2.tgz",
-      "integrity": "sha512-YHlZCB6lMTllWDtSPHz/ZXTsi8S00usEV6v1tjq8tOUZzw7DpSDWVXjXDre6ed1w/pd495ODpHZYSdkRTsa0HA==",
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-3.2.3.tgz",
+      "integrity": "sha512-byiJ0FLRdLdSVSReO/U4E7RoEyOCKnEnEPMjq3HxWtvzLsV08/i5RQKsFVNkCldrCaPr2vDNAOMsfs8T/Hze7g==",
       "license": "MIT",
       "dependencies": {
-        "jwa": "^1.4.1",
+        "jwa": "^1.4.2",
         "safe-buffer": "^5.0.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.0.3-alpha.1",
       "license": "MIT",
       "dependencies": {
-        "@natlibfi/passport-keycloak": "^3.0.3-alpha.1",
+        "@natlibfi/passport-keycloak": "^3.0.4",
         "debug": "^4.4.3",
         "passport": "^0.7.0",
         "passport-http": "^0.3.0",
@@ -671,9 +671,9 @@
       }
     },
     "node_modules/@natlibfi/passport-keycloak": {
-      "version": "3.0.3-alpha.1",
-      "resolved": "https://registry.npmjs.org/@natlibfi/passport-keycloak/-/passport-keycloak-3.0.3-alpha.1.tgz",
-      "integrity": "sha512-zaxNMe92b9bWuauhlnyT3JBEug7n3VX1iO+bRglmW2pD9Ijuo5bUbhqzqAw/8+ebfqooCFETHH7Qcssj7u6osQ==",
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@natlibfi/passport-keycloak/-/passport-keycloak-3.0.4.tgz",
+      "integrity": "sha512-KTd4BcDIia4/5yWfpX88jflEcW+OBh1EKln9PHCiKVb4zXxqOJ998WLaus/2tv4047vF3lBsl/dhZDXTG3I5xw==",
       "license": "MIT",
       "dependencies": {
         "debug": "^4.4.3",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/NatLibFi/passport-natlibfi-keycloak-js"
   },
   "license": "MIT",
-  "version": "3.0.4-alpha.1",
+  "version": "3.0.4",
   "main": "./dist/index.js",
   "type": "module",
   "engines": {

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "dev:debug": "cross-env LOG_LEVEL=debug DEBUG=@natlibfi/* NODE_ENV=test npm run watch:test"
   },
   "dependencies": {
-    "@natlibfi/passport-keycloak": "^3.0.3-alpha.1",
+    "@natlibfi/passport-keycloak": "^3.0.4",
     "debug": "^4.4.3",
     "passport": "^0.7.0",
     "passport-http": "^0.3.0",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "url": "https://github.com/NatLibFi/passport-natlibfi-keycloak-js"
   },
   "license": "MIT",
-  "version": "3.0.3-alpha.1",
+  "version": "3.0.4-alpha.1",
   "main": "./dist/index.js",
   "type": "module",
   "engines": {


### PR DESCRIPTION
* Update dependencies
* v3.0.4-alpha.1 and v3.0.4 to update both stable and next (note skipping one patch version to keep versioning consistent with passport-keycloak-js)